### PR TITLE
Fix mkdir error when running model training twice

### DIFF
--- a/code/5_model_train.py
+++ b/code/5_model_train.py
@@ -93,6 +93,6 @@ cls_report = classification_report(y_test, y_pred, target_names=targets)
 print(cls_report)
 
 # save model
-os.makedirs("models")
+os.makedirs("models", exist_ok=True)
 dump(pipe, "models/pipe.joblib")
 dump(ct, "models/ct.joblib")


### PR DESCRIPTION
Script uses os.makedirs, which errors if the directory already exists. This fix allows the directory to already exist. The result is that new models will overwrite previous ones, instead of the script erroring.